### PR TITLE
FIX: Ui Scale System

### DIFF
--- a/UI_SCALE_TECHNICAL_README.md
+++ b/UI_SCALE_TECHNICAL_README.md
@@ -1,0 +1,282 @@
+# UI Scale System - Technical Documentation
+
+**Author**: Mirag1993
+
+## Overview
+
+The UI Scale system allows players to adjust the size of game interface elements (TGUI windows and BYOND browser windows) to improve readability and usability. The system supports scaling from 0.8x to 1.2x (80% to 120% of original size).
+
+## Architecture
+
+The UI Scale system consists of three main components:
+
+1. **Backend (DM)**: Player preferences storage and data transmission
+2. **BYOND Browser Scaling**: Window size and content scaling for browser-based UIs
+3. **TGUI Frontend Scaling**: CSS-based scaling for React-based interfaces
+
+## Backend Implementation
+
+### Preferences Structure
+
+**File**: `code/modules/client/preferences.dm`
+
+```dm
+// UI Scale constants - range for user interface scaling
+#define UI_SCALE_MIN 0.8
+#define UI_SCALE_MAX 1.2
+
+/datum/preferences
+    var/ui_scale_enabled = FALSE  // Boolean: whether UI Scale is enabled
+    var/ui_scale_value = 1.0      // Float: scale factor value (0.8-1.2)
+```
+
+### Data Transmission
+
+**File**: `code/modules/tgui/tgui.dm`
+
+The backend transmits UI Scale data to TGUI through the config object:
+
+```dm
+"ui_scale" = user.client?.prefs?.get_ui_scale_data()
+```
+
+The `get_ui_scale_data()` method returns:
+```dm
+return list(
+    "enabled" = ui_scale_enabled,
+    "value" = ui_scale_value,
+    "min" = UI_SCALE_MIN,
+    "max" = UI_SCALE_MAX
+)
+```
+
+### Savefile Management
+
+**File**: `code/modules/client/preferences_savefile.dm`
+
+- Preferences are saved with version tracking
+- Values are clamped to valid range (0.8-1.2) on load and save
+- Backward compatibility maintained for older save files
+
+## BYOND Browser Scaling
+
+**File**: `code/datums/browser.dm`
+
+BYOND browser windows (like admin panels, player info, etc.) are scaled through two mechanisms:
+
+### 1. Window Size Scaling
+```dm
+// Apply UI Scale to window dimensions when enabled
+if(user.client?.prefs?.ui_scale_enabled)
+    var/scaling = user.client.prefs.ui_scale_value
+    window_size = "size=[width * scaling]x[height * scaling];"
+```
+
+### 2. Content Scaling
+```dm
+// CSS zoom for UI Scale when enabled - scales browser window content
+else if(user.client?.prefs?.ui_scale_enabled && user.client?.prefs?.ui_scale_value && user.client?.prefs.ui_scale_value != 1)
+    head_content += {"
+        <style>
+            body {
+                zoom: [user.client.prefs.ui_scale_value * 100]%;
+            }
+        </style>
+        "}
+```
+
+This approach ensures that both the window dimensions and content scale proportionally.
+
+## TGUI Frontend Scaling
+
+### React Hook Implementation
+
+**File**: `tgui/packages/tgui/hooks/useUiScale.ts`
+
+The `useUiScale` hook applies scaling through multiple CSS mechanisms:
+
+```typescript
+// Apply UI Scale only when enabled
+if (uiScale?.enabled && uiScale?.value) {
+  // Set --scaling-amount for vp() functions
+  document.documentElement.style.setProperty(
+    '--scaling-amount',
+    String(uiScale.value),
+  );
+  // Set --tgui-scale for content containers
+  document.documentElement.style.setProperty(
+    '--tgui-scale',
+    String(uiScale.value),
+  );
+  // Apply scaling to base font size for rem-based elements
+  document.documentElement.style.fontSize = `${12 * uiScale.value}px`;
+}
+```
+
+### CSS Implementation
+
+**File**: `tgui/packages/tgui/styles/ui-scale.scss`
+
+The CSS applies `zoom` property to content containers while preserving title bar sizes:
+
+```scss
+// Apply scaling to main content containers and interactive elements
+.Window__content,
+.Layout__content,
+.Section__content,
+.Section,
+.Stack,
+.LabeledList,
+.Table,
+.Button,
+.Input,
+.Slider {
+  zoom: var(--tgui-scale, 1);
+}
+
+// Exclude title bars from additional scaling since they are already
+// scaled through font-size changes to avoid double scaling
+.TitleBar,
+.TitleBar__title,
+.Window__titleText {
+  zoom: 1 !important;
+}
+```
+
+### Integration Point
+
+**File**: `tgui/packages/tgui/App.tsx`
+
+The hook is applied globally at the root level:
+
+```typescript
+export function App() {
+  // Apply UI Scale through TGUI's built-in scaling system
+  useUiScale();
+  
+  return <Component />;
+}
+```
+
+## Scaling Methods Explained
+
+### 1. CSS Zoom Property
+- **Used for**: TGUI content containers and BYOND browser content
+- **Advantages**: Scales everything proportionally (text, images, spacing)
+- **Disadvantages**: None significant for this use case
+
+### 2. Font-size Scaling
+- **Used for**: rem-based elements (primarily titles)
+- **Method**: Adjusts `document.documentElement.style.fontSize`
+- **Base**: 12px (TGUI standard)
+
+### 3. CSS Variables
+- **`--scaling-amount`**: Used by TGUI's `vp()` function (limited usage)
+- **`--tgui-scale`**: Custom variable for content containers
+
+## User Interface
+
+### Preferences Menu
+
+Players can:
+1. **Toggle UI Scale**: ON/OFF switch (`ui_scale_enabled`)
+2. **Set Scale Value**: Input field for precise value (`ui_scale_value`)
+   - Range: 0.8 to 1.2
+   - Default: 1.0
+   - Only visible when UI Scale is enabled
+
+### Input Validation
+
+All user inputs are validated and clamped:
+```dm
+ui_scale_value = clamp(ui_scale_value, UI_SCALE_MIN, UI_SCALE_MAX)
+```
+
+## Admin Panel Integration
+
+**Files**: 
+- `code/modules/admin/player_panel.dm`
+- `code/modules/admin/view_variables/view_variables.dm`
+
+Admin panels respect UI Scale settings and scale their windows accordingly to maintain usability for administrators with different scale preferences.
+
+## Technical Considerations
+
+### Performance
+- CSS zoom is hardware-accelerated and performant
+- No layout recalculations required
+- Minimal JavaScript overhead
+
+### Compatibility
+- Works with BYOND 516+
+- Compatible with all browsers used by TGUI
+- Backward compatible with older save files
+
+### Limitations
+- Scale range limited to 0.8-1.2 to prevent usability issues
+- Some pixel-perfect layouts may show minor artifacts at extreme scales
+- Title bars intentionally excluded from content scaling to maintain window aesthetics
+
+## Testing
+
+### Test Cases
+1. **Default State**: New players have UI Scale OFF, value 1.0
+2. **Range Validation**: Values outside 0.8-1.2 are clamped
+3. **Save/Load**: Settings persist across sessions
+4. **BYOND Windows**: Browser windows scale correctly
+5. **TGUI Windows**: Interface elements scale proportionally
+6. **Title Preservation**: Window titles maintain appropriate size
+
+### Manual Testing
+1. Create new character → verify defaults
+2. Enable UI Scale, set to 0.8 → verify smaller interface
+3. Set to 1.2 → verify larger interface
+4. Disable UI Scale → verify return to normal size
+5. Restart game → verify settings persistence
+
+## Debugging
+
+### Common Issues
+1. **Text still large when disabled**: Check `document.documentElement.style.fontSize` is reset to 12px
+2. **BYOND windows not scaling**: Verify `ui_scale_enabled` and `ui_scale_value` are correctly read
+3. **Title bars wrong size**: Ensure `zoom: 1 !important` is applied to title elements
+
+### Debug Tools
+- Browser DevTools: Check CSS variables and computed styles
+- DM compiler: Verify no undefined variables
+- TGUI console: Check for JavaScript errors
+
+## Future Improvements
+
+### Potential Enhancements
+1. **Panel-specific scaling**: Different scales for different interface types
+2. **Accessibility integration**: Integration with system accessibility settings
+3. **Dynamic range**: Adjustable min/max values based on screen resolution
+4. **Smooth transitions**: CSS transitions for scale changes
+
+### Code Maintenance
+- Keep CSS selectors up to date with TGUI component changes
+- Monitor performance impact of additional scaled elements
+- Regular testing across different browsers and screen sizes
+
+---
+
+## File Modification Summary
+
+### Modified Files
+- `code/modules/client/preferences.dm` - Backend preferences and UI
+- `code/modules/client/preferences_savefile.dm` - Save/load logic
+- `code/modules/tgui/tgui.dm` - Data transmission to frontend
+- `code/datums/browser.dm` - BYOND window scaling
+- `code/modules/admin/player_panel.dm` - Admin panel scaling
+- `code/modules/admin/view_variables/view_variables.dm` - View variables scaling
+- `tgui/packages/tgui/App.tsx` - React hook integration
+- `tgui/packages/tgui/hooks/useUiScale.ts` - Scaling logic
+- `tgui/packages/tgui/styles/main.scss` - CSS import
+- `tgui/packages/tgui/styles/ui-scale.scss` - Scaling styles
+
+### Added Files
+- `tgui/packages/tgui/hooks/useUiScale.ts` - React hook for scaling
+- `tgui/packages/tgui/styles/ui-scale.scss` - CSS scaling rules
+
+This implementation provides a robust, user-friendly UI scaling system that respects player preferences while maintaining interface integrity and performance.

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -66,11 +66,21 @@
 	for (file in stylesheets)
 		head_content += "<link rel='stylesheet' type='text/css' href='[SSassets.transport.get_asset_url(file)]'>"
 
-	if(user.client?.window_scaling && user.client?.window_scaling != 1 && !user.client?.prefs.ui_scale && width && height)
+	// CSS zoom to compensate window_scaling when UI Scale is disabled
+	if(user.client?.window_scaling && user.client?.window_scaling != 1 && !user.client?.prefs.ui_scale_enabled && width && height)
 		head_content += {"
 			<style>
 				body {
 					zoom: [100 / user.client?.window_scaling]%;
+				}
+			</style>
+			"}
+	// CSS zoom for UI Scale when enabled - scales browser window content
+	else if(user.client?.prefs?.ui_scale_enabled && user.client?.prefs?.ui_scale_value && user.client?.prefs.ui_scale_value != 1)
+		head_content += {"
+			<style>
+				body {
+					zoom: [user.client.prefs.ui_scale_value * 100]%;
 				}
 			</style>
 			"}
@@ -112,8 +122,9 @@
 		return
 	var/window_size = ""
 	if(width && height)
-		if(user.client?.prefs?.ui_scale)
-			var/scaling = user.client.window_scaling
+		// Apply UI Scale to window dimensions when enabled
+		if(user.client?.prefs?.ui_scale_enabled)
+			var/scaling = user.client.prefs.ui_scale_value
 			window_size = "size=[width * scaling]x[height * scaling];"
 		else
 			window_size = "size=[width]x[height];"

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -4,13 +4,13 @@
 	log_admin("[key_name(usr)] checked the player panel.")
 	var/dat = "<html><head><meta http-equiv='X-UA-Compatible' content='IE=edge; charset=UTF-8'/><title>Player Panel</title></head>"
 
-	var/ui_scale = owner.prefs.ui_scale
+	var/ui_scale_enabled = owner.prefs.ui_scale_enabled
 
 	//javascript, the part that does most of the work~
 	dat += {"
 
 		<head>
-			[!ui_scale && owner.window_scaling ? "<style>body {zoom: [100 / owner.window_scaling]%;}</style>" : ""]
+			[!ui_scale_enabled && owner.window_scaling ? "<style>body {zoom: [100 / owner.window_scaling]%;}</style>" : ""]
 
 			<script type='text/javascript'>
 
@@ -328,7 +328,9 @@
 	"}
 
 	var/window_size = "size=600x480"
-	if(owner.window_scaling && ui_scale)
-		window_size = "size=[600 * owner.window_scaling]x[400 * owner.window_scaling]"
+	// Apply UI Scale to admin panel window size when enabled
+	if(ui_scale_enabled && owner.prefs.ui_scale_value)
+		var/scaling = owner.prefs.ui_scale_value
+		window_size = "size=[600 * scaling]x[400 * scaling]"
 
 	usr << browse(dat, "window=players;[window_size]")

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -74,7 +74,7 @@
 			names += V
 	sleep(1)
 
-	var/ui_scale = prefs?.ui_scale
+	var/ui_scale_enabled = prefs?.ui_scale_enabled
 
 	var/list/variable_html = list()
 	if(islist)
@@ -97,7 +97,7 @@
 		<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
 		<title>[title]</title>
 		<link rel="stylesheet" type="text/css" href="[SSassets.transport.get_asset_url("view_variables.css")]">
-		[!ui_scale && window_scaling ? "<style>body {zoom: [100 / window_scaling]%;}</style>" : ""]
+		[!ui_scale_enabled && window_scaling ? "<style>body {zoom: [100 / window_scaling]%;}</style>" : ""]
 	</head>
 	<body onload='selectTextField()' onkeydown='return handle_keydown()' onkeyup='handle_keyup()'>
 		<script type="text/javascript">
@@ -265,8 +265,10 @@ datumrefresh=[refid];[HrefToken()]'>Refresh</a>
 </html>
 "}
 	var/size_string = "size=475x650";
-	if(ui_scale && window_scaling)
-		size_string = "size=[475 * window_scaling]x[650 * window_scaling]"
+	// Apply UI Scale to view variables window size when enabled
+	if(ui_scale_enabled && prefs?.ui_scale_value)
+		var/scaling = prefs.ui_scale_value
+		size_string = "size=[475 * scaling]x[650 * scaling]"
 
 	src << browse(html, "window=variables[refid];[size_string]")
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1,5 +1,9 @@
 GLOBAL_LIST_EMPTY(preferences_datums)
 
+// UI Scale constants - range for user interface scaling
+#define UI_SCALE_MIN 0.8
+#define UI_SCALE_MAX 1.2
+
 /datum/preferences
 	var/client/parent
 	//doohickeys for savefiles
@@ -47,7 +51,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/tgui_fancy = TRUE
 	var/tgui_lock = FALSE
-	var/ui_scale = FALSE
+	var/ui_scale_enabled = FALSE  // Boolean: whether UI Scale is enabled
+	var/ui_scale_value = 1.0      // Float: scale factor value (0.8-1.2)
 
 	var/windowflashing = TRUE
 	var/toggles = TOGGLES_DEFAULT
@@ -1012,7 +1017,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>UI Style:</b> <a href='byond://?_src_=prefs;task=input;preference=ui'>[UI_style]</a><br>"
 			dat += "<b>tgui Window Mode:</b> <a href='byond://?_src_=prefs;preference=tgui_fancy'>[(tgui_fancy) ? "Fancy (default)" : "Compatible (slower)"]</a><br>"
 			dat += "<b>tgui Window Placement:</b> <a href='byond://?_src_=prefs;preference=tgui_lock'>[(tgui_lock) ? "Primary monitor" : "Free (default)"]</a><br>"
-			dat += "<b>UI Scale:</b> <a href='byond://?_src_=prefs;preference=ui_scale'>[(ui_scale) ? "ON" : "OFF"]</a><br>"
+			dat += "<b>UI Scale:</b> <a href='byond://?_src_=prefs;preference=ui_scale_enabled'>[(ui_scale_enabled) ? "ON" : "OFF"]</a><br>"
+			if(ui_scale_enabled)
+				dat += "<b>UI Scale Value:</b> <a href='byond://?_src_=prefs;preference=ui_scale_value;task=input'>[ui_scale_value]</a><br>"
 			dat += "<b>Show Runechat Chat Bubbles:</b> <a href='byond://?_src_=prefs;preference=chat_on_map'>[chat_on_map ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Runechat message char limit:</b> <a href='byond://?_src_=prefs;preference=max_chat_length;task=input'>[max_chat_length]</a><br>"
 			dat += "<b>See Runechat for non-mobs:</b> <a href='byond://?_src_=prefs;preference=see_chat_non_mob'>[see_chat_non_mob ? "Enabled" : "Disabled"]</a><br>"
@@ -2154,6 +2161,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if (!isnull(desiredlength))
 						max_chat_length = clamp(desiredlength, 1, CHAT_MESSAGE_MAX_LENGTH)
 
+				if ("ui_scale_value")
+					var/new_scale = input(user, "Choose UI Scale value. Range [UI_SCALE_MIN]-[UI_SCALE_MAX] (default: 1.0)", "UI Scale Value", ui_scale_value) as null|num
+					if (!isnull(new_scale))
+						ui_scale_value = clamp(new_scale, UI_SCALE_MIN, UI_SCALE_MAX)
+
 		else
 			switch(href_list["preference"])
 				if("showgear")
@@ -2268,8 +2280,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					buttons_locked = !buttons_locked
 				if("tgui_fancy")
 					tgui_fancy = !tgui_fancy
-				if("ui_scale")
-					ui_scale = !ui_scale
+				if("ui_scale_enabled")
+					ui_scale_enabled = !ui_scale_enabled
 				if("outline_enabled")
 					outline_enabled = !outline_enabled
 				if("outline_color")
@@ -2608,3 +2620,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			return
 		else
 			custom_names[name_id] = sanitized_name
+
+/**
+ * Returns UI Scale data for transmission to TGUI frontend
+ * 
+ * @return list containing enabled status, scale value, and min/max bounds
+ */
+/datum/preferences/proc/get_ui_scale_data()
+	return list(
+		"enabled" = ui_scale_enabled,
+		"value" = ui_scale_value,
+		"min" = UI_SCALE_MIN,
+		"max" = UI_SCALE_MAX
+	)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -194,9 +194,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["tgui_lock"], tgui_lock)
 	// Ui scale only becomes a setting thats needed in 516
 	if(parent.byond_version >= 516)
-		READ_FILE(S["ui_scale"], ui_scale)
+		READ_FILE(S["ui_scale_enabled"], ui_scale_enabled)
+		READ_FILE(S["ui_scale_value"], ui_scale_value)
 	else
-		ui_scale = FALSE
+		ui_scale_enabled = FALSE
+		ui_scale_value = 1.0
 	READ_FILE(S["buttons_locked"], buttons_locked)
 	READ_FILE(S["windowflash"], windowflashing)
 	READ_FILE(S["be_special"] , be_special)
@@ -275,7 +277,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	broadcast_login_logout = sanitize_integer(broadcast_login_logout, FALSE, TRUE, initial(broadcast_login_logout))
 	tgui_fancy		= sanitize_integer(tgui_fancy, FALSE, TRUE, initial(tgui_fancy))
 	tgui_lock		= sanitize_integer(tgui_lock, FALSE, TRUE, initial(tgui_lock))
-	ui_scale		= sanitize_integer(ui_scale, FALSE, TRUE, initial(ui_scale))
+	ui_scale_enabled = sanitize_integer(ui_scale_enabled, FALSE, TRUE, initial(ui_scale_enabled))
+	ui_scale_value   = clamp(ui_scale_value, UI_SCALE_MIN, UI_SCALE_MAX)
 	buttons_locked	= sanitize_integer(buttons_locked, FALSE, TRUE, initial(buttons_locked))
 	windowflashing	= sanitize_integer(windowflashing, FALSE, TRUE, initial(windowflashing))
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
@@ -349,7 +352,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["broadcast_login_logout"], broadcast_login_logout)
 	WRITE_FILE(S["tgui_fancy"], tgui_fancy)
 	WRITE_FILE(S["tgui_lock"], tgui_lock)
-	WRITE_FILE(S["ui_scale"], ui_scale)
+	WRITE_FILE(S["ui_scale_enabled"], ui_scale_enabled)
+	WRITE_FILE(S["ui_scale_value"], ui_scale_value)
 	WRITE_FILE(S["buttons_locked"], buttons_locked)
 	WRITE_FILE(S["windowflash"], windowflashing)
 	WRITE_FILE(S["be_special"], be_special)

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -248,6 +248,8 @@
 			"name" = "[user]",
 			"observer" = isobserver(user),
 		),
+		// UI Scale data for TGUI frontend scaling
+		"ui_scale" = user.client?.prefs?.get_ui_scale_data(),
 	)
 	var/data = custom_data || with_data && src_object.ui_data(user)
 	if(data)

--- a/tgui/packages/tgui/App.tsx
+++ b/tgui/packages/tgui/App.tsx
@@ -1,9 +1,13 @@
 import { globalStore } from './backend';
 import { IconProvider } from './Icons';
+import { useUiScale } from './hooks/useUiScale';
 
 export function App() {
   const { getRoutedComponent } = require('./routes');
   const Component = getRoutedComponent(globalStore);
+
+  // Apply UI Scale through TGUI's built-in scaling system
+  useUiScale();
 
   return (
     <>

--- a/tgui/packages/tgui/hooks/useUiScale.ts
+++ b/tgui/packages/tgui/hooks/useUiScale.ts
@@ -1,0 +1,53 @@
+/**
+ * @file
+ * @copyright 2025
+ * @license MIT
+ */
+
+import { useEffect } from 'react';
+
+import { useBackend } from '../backend';
+
+/**
+ * Hook for applying UI Scale through TGUI's built-in scaling system
+ * 
+ * Applies scaling via multiple methods:
+ * - --scaling-amount CSS variable for vp() functions
+ * - --tgui-scale CSS variable for content containers
+ * - font-size adjustment for rem-based elements
+ */
+export function useUiScale() {
+  const { config } = useBackend();
+  // Safely get ui_scale data with type checking
+  const uiScale = (config as any)?.ui_scale;
+
+  useEffect(() => {
+    // Apply UI Scale only when enabled
+    if (uiScale?.enabled && uiScale?.value) {
+      // Set --scaling-amount for vp() functions
+      document.documentElement.style.setProperty(
+        '--scaling-amount',
+        String(uiScale.value),
+      );
+      // Set --tgui-scale for content containers
+      document.documentElement.style.setProperty(
+        '--tgui-scale',
+        String(uiScale.value),
+      );
+      // Apply scaling to base font size for rem-based elements
+      document.documentElement.style.fontSize = `${12 * uiScale.value}px`;
+    } else {
+      // Reset to default values
+      document.documentElement.style.setProperty('--scaling-amount', '1');
+      document.documentElement.style.setProperty('--tgui-scale', '1');
+      document.documentElement.style.fontSize = '12px';
+    }
+
+    return () => {
+      // Cleanup on unmount
+      document.documentElement.style.setProperty('--scaling-amount', '1');
+      document.documentElement.style.setProperty('--tgui-scale', '1');
+      document.documentElement.style.fontSize = '12px';
+    };
+  }, [uiScale?.enabled, uiScale?.value]);
+}

--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -62,6 +62,9 @@
 
 @include meta.load-css('highlight.js/scss/github-dark.scss');
 
+// UI Scale support
+@include meta.load-css('./ui-scale.scss');
+
 // NT Theme
 .Layout__content {
   background-image: url('../assets/bg-shiptest.svg');

--- a/tgui/packages/tgui/styles/ui-scale.scss
+++ b/tgui/packages/tgui/styles/ui-scale.scss
@@ -1,0 +1,29 @@
+/**
+ * UI Scale support for TGUI content
+ * 
+ * This file provides CSS zoom-based scaling for TGUI interface elements
+ * when UI Scale is enabled in player preferences. The --tgui-scale CSS
+ * variable is set by the useUiScale React hook.
+ */
+
+// Apply scaling to main content containers and interactive elements
+.Window__content,
+.Layout__content,
+.Section__content,
+.Section,
+.Stack,
+.LabeledList,
+.Table,
+.Button,
+.Input,
+.Slider {
+  zoom: var(--tgui-scale, 1);
+}
+
+// Exclude title bars from additional scaling since they are already
+// scaled through font-size changes to avoid double scaling
+.TitleBar,
+.TitleBar__title,
+.Window__titleText {
+  zoom: 1 !important;
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The UI Scale system allows players to adjust the size of game interface elements (TGUI windows and BYOND browser windows) to improve readability and usability. The system supports scaling from 0.8x to 1.2x (80% to 120% of original size).

<img width="1919" height="1028" alt="image" src="https://github.com/user-attachments/assets/be7f8feb-157d-407e-b557-f0d18dc03f27" />

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/d384e60b-6d18-471f-9ae5-de6ef219f3ff" />


Now: You can change UI Scale in Settings.

<img width="349" height="160" alt="image" src="https://github.com/user-attachments/assets/17602068-8479-414b-8d53-6c575862978e" />
